### PR TITLE
Fix inconsistency with the forgot password view

### DIFF
--- a/app/views/spree/user_passwords/new.html.erb
+++ b/app/views/spree/user_passwords/new.html.erb
@@ -1,17 +1,21 @@
 <%= render partial: 'spree/shared/error_messages', locals: { target: @spree_user } %>
 
-<div id="forgot-password" class="row">
-  <div class="alert alert-info"><%= Spree.t(:forgot_password) %></div>
-
-  <p><%= Spree.t(:instructions_to_reset_password) %></p>
-
-  <%= form_for Spree::User.new, as: :spree_user, url: spree.reset_password_path do |f| %>
-    <div class="from-group">
-      <%= f.label :email, Spree.t(:email) %><br />
-      <%= f.email_field :email %>
+<div class="col-md-4 col-md-offset-4">
+  <div id="forgot-password" class="panel panel-default">
+    <div class="panel panel-heading"><%= Spree.t(:forgot_password) %></div>
+    <div class="panel panel-body" >
+      <div class=""><%= Spree.t(:instructions_to_reset_password) %></div>
+      <br>
+      <%= form_for Spree::User.new, as: :spree_user, url: spree.reset_password_path do |f| %>
+      <div class="from-group">
+        <%= f.label :email, Spree.t(:email) %><br />
+        <%= f.email_field :email, class: 'title form-control' %>
+      </div>
+      <br>
+      <div class="actions">
+        <%= f.submit Spree.t(:reset_password), class: 'btn btn-success btn-block' %>
+      </div>
+      <% end %>
     </div>
-    <div class="actions">
-      <%= f.submit Spree.t(:reset_password), class: 'btn btn-success btn-block' %>
-    </div>
-  <% end %>
+  </div>
 </div>

--- a/app/views/spree/user_passwords/new.html.erb
+++ b/app/views/spree/user_passwords/new.html.erb
@@ -1,11 +1,11 @@
 <%= render partial: 'spree/shared/error_messages', locals: { target: @spree_user } %>
-
+<br><br>
 <div class="col-md-4 col-md-offset-4">
   <div id="forgot-password" class="panel panel-default">
-    <div class="panel panel-heading"><%= Spree.t(:forgot_password) %></div>
-    <div class="panel panel-body" >
+    <div class="panel-heading"><%= Spree.t(:forgot_password) %></div>
+    <div class="panel-body" >
       <div class=""><%= Spree.t(:instructions_to_reset_password) %></div>
-      <br>
+      <hr>
       <%= form_for Spree::User.new, as: :spree_user, url: spree.reset_password_path do |f| %>
       <div class="from-group">
         <%= f.label :email, Spree.t(:email) %><br />


### PR DESCRIPTION
closes #7 
### Before changes
There was an inconsistency with panel implemented for bootstrap styles and the space between the panel and the top of the page was not the right one.
![screen shot 2018-11-06 at 22 07 54](https://user-images.githubusercontent.com/42420295/48111262-5fd8c600-e216-11e8-865a-9404096cfe6c.png)

### After Changes
The view is now consistent with the remaining user views.
![screen shot 2018-11-06 at 22 51 31](https://user-images.githubusercontent.com/42420295/48111315-90206480-e216-11e8-8030-097c2a296772.png)


 

