### PR TITLE
Ticket #4 resolve, still pending wireframes

### DIFF
--- a/app/views/spree/base/_application.html.erb
+++ b/app/views/spree/base/_application.html.erb
@@ -6,7 +6,7 @@
   <%#= taxon_breadcrumbs(@taxon) %>
   <%#= render partial: 'spree/shared/search' %><br>
 
-  <%#= render partial: 'spree/shared/sidebar' if content_for? :sidebar %>
+  <%= render partial: 'spree/shared/sidebar' if content_for? :sidebar %>
 
   <div id="content" class="columns <%= !content_for?(:sidebar) ? "sixteen" : "twelve omega" %>" data-hook>
     <%= flash_messages %>

--- a/app/views/spree/shared/_filters.html.erb
+++ b/app/views/spree/shared/_filters.html.erb
@@ -22,6 +22,6 @@
         </ul>
       </div>
     <% end %>
-    <%= submit_tag t('spree.search'), name: nil, class: "button btn btn-success btn-block" %>
+    <%= submit_tag t('spree.search'), name: nil, class: "button" %>
   <% end %>
 <% end %>


### PR DESCRIPTION
closes #4 

Render the sidebar with ranges at the top of the page before products, pending definition on style (wireframes)

###Before changes
There was no options to narrow a search
![screen shot 2018-11-06 at 23 46 25](https://user-images.githubusercontent.com/42420295/48112926-2e63f880-e21e-11e8-93d1-aa7350e3683c.png)

###After changes
Now we have options to reduce the options according to a price range
![screen shot 2018-11-06 at 23 45 40](https://user-images.githubusercontent.com/42420295/48112910-168c7480-e21e-11e8-9068-910f23816099.png)


