### PR TITLE
Solidus Stripe

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,7 +39,11 @@ gem 'wkhtmltopdf-binary'
 gem 'solidus'
 gem 'solidus_auth_devise'
 
+# Bootstrap SASS for twitter bootstrap styling
 gem 'bootstrap-sass'
+
+# Payment processing with Stripe
+gem "solidus_stripe",  git: 'https://github.com/solidusio-contrib/solidus_stripe'
 
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.1.0', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,12 @@
+GIT
+  remote: https://github.com/solidusio-contrib/solidus_stripe
+  revision: d04d4b6a8b3cafe69152e5aa8878403f529a6e01
+  specs:
+    solidus_stripe (1.0.0)
+      activemerchant (~> 1.48, != 1.59.0, != 1.58.0)
+      solidus_core (>= 1.1, < 3)
+      solidus_support (>= 0.1.3)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -374,6 +383,7 @@ DEPENDENCIES
   selenium-webdriver
   solidus
   solidus_auth_devise
+  solidus_stripe!
   spring
   spring-watcher-listen (~> 2.0.0)
   turbolinks (~> 5)


### PR DESCRIPTION
closes #3 
Now the payment section has the option to make payments thru the Stripe Gateway.
### Before Changes.
The payments were process by the default solidus gateway.
![screen shot 2018-11-07 at 10 38 28](https://user-images.githubusercontent.com/42420295/48145831-52a0f300-e279-11e8-8648-5005ddc312f2.png)
![screen shot 2018-11-07 at 10 38 20](https://user-images.githubusercontent.com/42420295/48145846-5af92e00-e279-11e8-9292-65452896f715.png)


### After Changes.
The payments are process thru stripe gateway instead.

![screen shot 2018-11-07 at 10 31 31](https://user-images.githubusercontent.com/42420295/48145361-4e280a80-e278-11e8-80eb-bb6355bd826d.png)
![screen shot 2018-11-07 at 10 31 20](https://user-images.githubusercontent.com/42420295/48145384-58e29f80-e278-11e8-977b-d5e91b4720af.png)


The only thing that would be missing is the configuration on the Solidus admin directly, for when it is deployed.