### PR TITLE
Features/paypal express

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,6 +45,9 @@ gem 'bootstrap-sass'
 # Payment processing with Stripe
 gem "solidus_stripe",  git: 'https://github.com/solidusio-contrib/solidus_stripe'
 
+# Payment processor with Paypal Tapia´s Gem
+gem 'solidus_paypal_express', github: 'jtapia/better_solidus_paypal_express'
+
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.1.0', require: false
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,6 +9,16 @@ GIT
       solidus_support
 
 GIT
+  remote: https://github.com/jtapia/better_solidus_paypal_express.git
+  revision: fd5aca766f57b0ef9d89cebb835d1c4d5a69d5da
+  specs:
+    solidus_paypal_express (2.0.0.beta)
+      deface (~> 1.0)
+      paypal-sdk-merchant
+      solidus_core (> 1.2, < 3)
+      solidus_support
+
+GIT
   remote: https://github.com/solidusio-contrib/solidus_stripe
   revision: d04d4b6a8b3cafe69152e5aa8878403f529a6e01
   specs:
@@ -205,6 +215,11 @@ GEM
       terrapin (~> 0.6.0)
     paranoia (2.4.1)
       activerecord (>= 4.0, < 5.3)
+    paypal-sdk-core (0.3.4)
+      multi_json (~> 1.0)
+      xml-simple
+    paypal-sdk-merchant (1.117.2)
+      paypal-sdk-core (~> 0.3.0)
     pg (1.1.3)
     polyglot (0.3.5)
     pry (0.11.3)
@@ -376,6 +391,7 @@ GEM
     websocket-extensions (0.1.3)
     wicked_pdf (1.1.0)
     wkhtmltopdf-binary (0.12.4)
+    xml-simple (1.1.5)
     xpath (3.2.0)
       nokogiri (~> 1.8)
 
@@ -401,6 +417,7 @@ DEPENDENCIES
   solidus
   solidus_auth_devise
   solidus_import_products!
+  solidus_paypal_express!
   solidus_stripe!
   spring
   spring-watcher-listen (~> 2.0.0)

--- a/db/migrate/20181108222039_create_spree_paypal_express_checkouts.solidus_paypal_express.rb
+++ b/db/migrate/20181108222039_create_spree_paypal_express_checkouts.solidus_paypal_express.rb
@@ -1,0 +1,9 @@
+# This migration comes from solidus_paypal_express (originally 20130723042610)
+class CreateSpreePaypalExpressCheckouts < SolidusSupport::Migration[4.2]
+  def change
+    create_table :spree_paypal_express_checkouts do |t|
+      t.string :token
+      t.string :payer_id
+    end
+  end
+end

--- a/db/migrate/20181108222040_add_transaction_id_to_spree_paypal_express_checkouts.solidus_paypal_express.rb
+++ b/db/migrate/20181108222040_add_transaction_id_to_spree_paypal_express_checkouts.solidus_paypal_express.rb
@@ -1,0 +1,7 @@
+# This migration comes from solidus_paypal_express (originally 20130808030836)
+class AddTransactionIdToSpreePaypalExpressCheckouts < SolidusSupport::Migration[4.2]
+  def change
+    add_column :spree_paypal_express_checkouts, :transaction_id, :string
+    add_index :spree_paypal_express_checkouts, :transaction_id
+  end
+end

--- a/db/migrate/20181108222041_add_state_to_spree_paypal_express_checkouts.solidus_paypal_express.rb
+++ b/db/migrate/20181108222041_add_state_to_spree_paypal_express_checkouts.solidus_paypal_express.rb
@@ -1,0 +1,6 @@
+# This migration comes from solidus_paypal_express (originally 20130809013846)
+class AddStateToSpreePaypalExpressCheckouts < SolidusSupport::Migration[4.2]
+  def change
+    add_column :spree_paypal_express_checkouts, :state, :string, default: 'complete'
+  end
+end

--- a/db/migrate/20181108222042_add_refunded_fields_to_spree_paypal_express_checkouts.solidus_paypal_express.rb
+++ b/db/migrate/20181108222042_add_refunded_fields_to_spree_paypal_express_checkouts.solidus_paypal_express.rb
@@ -1,0 +1,9 @@
+# This migration comes from solidus_paypal_express (originally 20130809014319)
+class AddRefundedFieldsToSpreePaypalExpressCheckouts < SolidusSupport::Migration[4.2]
+  def change
+    add_column :spree_paypal_express_checkouts, :refund_transaction_id, :string
+    add_column :spree_paypal_express_checkouts, :refunded_at, :datetime
+    add_column :spree_paypal_express_checkouts, :refund_type, :string
+    add_column :spree_paypal_express_checkouts, :created_at, :datetime
+  end
+end

--- a/db/migrate/20181108222043_rename_payment_methods.solidus_paypal_express.rb
+++ b/db/migrate/20181108222043_rename_payment_methods.solidus_paypal_express.rb
@@ -1,0 +1,14 @@
+# This migration comes from solidus_paypal_express (originally 20140117051315)
+class RenamePaymentMethods < SolidusSupport::Migration[4.2]
+  def up
+    execute <<-SQL
+      update spree_payment_methods set type = 'Spree::Gateway::PayPalExpress' WHERE type = 'Spree::BillingIntegration::PaypalExpress'
+    SQL
+  end
+
+  def down
+    execute <<-SQL
+      update spree_payment_methods set type = 'Spree::BillingIntegration::PaypalExpress' WHERE type = 'Spree::Gateway::PayPalExpress'
+    SQL
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_11_07_172212) do
+ActiveRecord::Schema.define(version: 2018_11_08_222043) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -47,37 +47,6 @@ ActiveRecord::Schema.define(version: 2018_11_07_172212) do
     t.index ["slug", "sluggable_type"], name: "index_friendly_id_slugs_on_slug_and_sluggable_type"
     t.index ["sluggable_id"], name: "index_friendly_id_slugs_on_sluggable_id"
     t.index ["sluggable_type"], name: "index_friendly_id_slugs_on_sluggable_type"
-  end
-
-  create_table "solidus_paypal_braintree_configurations", id: :serial, force: :cascade do |t|
-    t.boolean "paypal", default: false, null: false
-    t.boolean "apple_pay", default: false, null: false
-    t.integer "store_id", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.boolean "credit_card", default: false, null: false
-    t.index ["store_id"], name: "index_solidus_paypal_braintree_configurations_on_store_id"
-  end
-
-  create_table "solidus_paypal_braintree_customers", id: :serial, force: :cascade do |t|
-    t.integer "user_id"
-    t.string "braintree_customer_id"
-    t.index ["braintree_customer_id"], name: "index_braintree_customers_on_braintree_customer_id", unique: true
-    t.index ["user_id"], name: "index_braintree_customers_on_user_id", unique: true
-  end
-
-  create_table "solidus_paypal_braintree_sources", id: :serial, force: :cascade do |t|
-    t.string "nonce"
-    t.string "token"
-    t.string "payment_type", null: false
-    t.integer "user_id"
-    t.integer "customer_id"
-    t.integer "payment_method_id", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["customer_id"], name: "index_solidus_paypal_braintree_sources_on_customer_id"
-    t.index ["payment_method_id"], name: "index_solidus_paypal_braintree_sources_on_payment_method_id"
-    t.index ["user_id"], name: "index_solidus_paypal_braintree_sources_on_user_id"
   end
 
   create_table "spree_addresses", id: :serial, force: :cascade do |t|
@@ -409,6 +378,18 @@ ActiveRecord::Schema.define(version: 2018_11_07_172212) do
     t.index ["order_id"], name: "index_spree_payments_on_order_id"
     t.index ["payment_method_id"], name: "index_spree_payments_on_payment_method_id"
     t.index ["source_id", "source_type"], name: "index_spree_payments_on_source_id_and_source_type"
+  end
+
+  create_table "spree_paypal_express_checkouts", id: :serial, force: :cascade do |t|
+    t.string "token"
+    t.string "payer_id"
+    t.string "transaction_id"
+    t.string "state", default: "complete"
+    t.string "refund_transaction_id"
+    t.datetime "refunded_at"
+    t.string "refund_type"
+    t.datetime "created_at"
+    t.index ["transaction_id"], name: "index_spree_paypal_express_checkouts_on_transaction_id"
   end
 
   create_table "spree_preferences", id: :serial, force: :cascade do |t|
@@ -1235,7 +1216,6 @@ ActiveRecord::Schema.define(version: 2018_11_07_172212) do
     t.datetime "updated_at", precision: 6
   end
 
-  add_foreign_key "solidus_paypal_braintree_sources", "spree_payment_methods", column: "payment_method_id"
   add_foreign_key "spree_promotion_code_batches", "spree_promotions", column: "promotion_id"
   add_foreign_key "spree_promotion_codes", "spree_promotion_code_batches", column: "promotion_code_batch_id"
   add_foreign_key "spree_tax_rate_tax_categories", "spree_tax_categories", column: "tax_category_id"

--- a/vendor/assets/javascripts/spree/backend/all.js
+++ b/vendor/assets/javascripts/spree/backend/all.js
@@ -8,3 +8,4 @@
 //= require jquery_ujs
 //= require spree/backend
 //= require_tree .
+//= require spree/backend/solidus_paypal_express

--- a/vendor/assets/javascripts/spree/frontend/all.js
+++ b/vendor/assets/javascripts/spree/frontend/all.js
@@ -8,3 +8,4 @@
 //= require jquery_ujs
 //= require spree/frontend
 //= require_tree .
+//= require spree/frontend/solidus_paypal_express

--- a/vendor/assets/stylesheets/spree/backend/all.css
+++ b/vendor/assets/stylesheets/spree/backend/all.css
@@ -6,4 +6,5 @@
  *= require spree/backend
  *= require_self
  *= require_tree .
+ *= require spree/backend/solidus_paypal_express
 */

--- a/vendor/assets/stylesheets/spree/frontend/all.css
+++ b/vendor/assets/stylesheets/spree/frontend/all.css
@@ -6,4 +6,5 @@
  *= require spree/frontend
  *= require_self
  *= require_tree .
+ *= require spree/frontend/solidus_paypal_express
 */


### PR DESCRIPTION
closes #13 
Enables the option for PayPal payments.
### Before changes
The only option to make payments was with credit card and thru stripe.
![screen shot 2018-11-08 at 21 10 34](https://user-images.githubusercontent.com/42420295/48241027-c7b81980-e39a-11e8-8680-56baad6a4a31.png)
![screen shot 2018-11-08 at 21 10 28](https://user-images.githubusercontent.com/42420295/48241043-d1da1800-e39a-11e8-96ac-cf60f6af8a64.png)


### After changes
Now it is also posible to make payments thru PayPal, by simply login to the users account on PayPal and accept the payment.

![screen shot 2018-11-08 at 21 01 46](https://user-images.githubusercontent.com/42420295/48240900-3ea0e280-e39a-11e8-8cb3-bcd77c0fccb0.png)
![screen shot 2018-11-08 at 21 02 00](https://user-images.githubusercontent.com/42420295/48240912-4bbdd180-e39a-11e8-8907-76a59e4113ea.png)
