### PR TITLE
Include helper to render top and bottom banner only in the index view

### DIFF
--- a/app/views/spree/base/_application.html.erb
+++ b/app/views/spree/base/_application.html.erb
@@ -1,5 +1,6 @@
 <%= render partial: 'spree/shared/header' %>
-<%= render partial: 'spree/home/top_banner' %>
+<%= render partial: 'spree/home/top_banner' if current_page?(root_path) %>
+
 <div class="container">
 	<div id="wrapper" class="row" data-hook>
 
@@ -17,5 +18,5 @@
 
 	</div>
 </div>
-<%= render partial: 'spree/home/bottom_banner' %>
+<%= render partial: 'spree/home/bottom_banner' if current_page?(root_path) %>
 <%= render partial: 'spree/shared/footer' %>


### PR DESCRIPTION
closes #28 
### Before Changes
The top and bottom banner that we only need at the home page is being render thru the whole site, this can be fix with a helper current_page?(root_to_evaluate).
Home page was ok as shown below.
![screen shot 2018-11-19 at 20 18 18](https://user-images.githubusercontent.com/42420295/48747317-9102be80-ec38-11e8-80b7-570de3c27616.png)
![screen shot 2018-11-19 at 20 18 29](https://user-images.githubusercontent.com/42420295/48747318-92cc8200-ec38-11e8-91c5-423b599cc824.png)
![screen shot 2018-11-19 at 20 18 40](https://user-images.githubusercontent.com/42420295/48747322-95c77280-ec38-11e8-8938-a376cf5ea9c1.png)
But the remaining views should not render those banners any more (Example below is the car view).
![screen shot 2018-11-19 at 20 22 14](https://user-images.githubusercontent.com/42420295/48747412-e76ffd00-ec38-11e8-996a-f0a2eb41e662.png)
![screen shot 2018-11-19 at 20 22 22](https://user-images.githubusercontent.com/42420295/48747414-e939c080-ec38-11e8-9605-fbd92838cd85.png)

### After Changes.
Include helper current_page to determine wether the current page that the user is on is the home page or not, if it is the home page then the top and bottom banners will be rendered if not then nothing for those sections will be rendered.
Home page remains ok as shown below.
![screen shot 2018-11-19 at 11 27 32](https://user-images.githubusercontent.com/42420295/48747426-fc4c9080-ec38-11e8-8b2d-d81e02572c83.png)
![screen shot 2018-11-19 at 11 27 50](https://user-images.githubusercontent.com/42420295/48747430-fe165400-ec38-11e8-82fe-00e258d6ac2b.png)
![screen shot 2018-11-19 at 11 27 58](https://user-images.githubusercontent.com/42420295/48747433-ff478100-ec38-11e8-8a48-9ef5844c6d99.png)
But now the other views do not render anything (Example below shows car without those banners).
![screen shot 2018-11-19 at 20 21 02](https://user-images.githubusercontent.com/42420295/48747368-bdb6d600-ec38-11e8-8076-e6424430044b.png)
